### PR TITLE
docs: add governed MCP client guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,8 @@ To use with an MCP client:
 2. Connect your MCP-compatible client to the server
 3. The client will be able to use the available tools to interact with your Rails projects
 
+For teams using a governed AI client or control plane for tool access, approvals, audit trails, and cost reporting, see [Governed MCP Clients](docs/GOVERNED_CLIENTS.md).
+
 ## Security
 
 For security concerns, please see [SECURITY.md](SECURITY.md).

--- a/docs/GOVERNED_CLIENTS.md
+++ b/docs/GOVERNED_CLIENTS.md
@@ -1,0 +1,44 @@
+# Governed MCP Clients
+
+Rails MCP Server exposes Rails project tools and documentation resources through the Model Context Protocol. Some teams connect those MCP tools to a governed AI client or control plane so tool access, audit trails, approvals, and cost controls can be managed centrally.
+
+This guide describes the integration pattern. Rails MCP Server continues to own the Rails project tools and resources. The governed client or gateway owns model access, policy decisions, and cross-application reporting.
+
+## Pattern
+
+1. Start Rails MCP Server in STDIO or HTTP mode.
+2. Register the server with an MCP-compatible client or control plane.
+3. Let the client decide which users, roles, or agents can call Rails MCP tools.
+4. Keep Rails project paths and credentials local to the Rails MCP Server environment.
+
+## Example: Tuning Engines
+
+Tuning Engines can be used as a governed AI control plane in front of model, agent, and MCP workflows. In this setup:
+
+- Rails MCP Server provides tools such as `switch_project`, `search_tools`, `execute_tool`, and `load_guide`.
+- The MCP client or control plane registers the Rails MCP Server and discovers its tools.
+- Tuning Engines can enforce tenant, role, or policy-based access to MCP tools and record traces/costs for model and tool activity.
+
+For local development, start Rails MCP Server normally:
+
+```bash
+rails-mcp-server
+```
+
+For HTTP/SSE testing or a local proxy:
+
+```bash
+rails-mcp-server --mode http
+```
+
+Then configure your MCP-compatible client or control plane to connect to the STDIO command or HTTP/SSE endpoint.
+
+## Security notes
+
+- Do not expose Rails MCP Server on an untrusted network.
+- Prefer STDIO or localhost HTTP mode unless you have a trusted network and explicit access controls.
+- Keep Rails project paths, credentials, and `.env` files local to the server.
+- Use the governed client to restrict high-risk tools such as code execution or broad project scans.
+- Preserve request IDs or trace IDs in client metadata when available so tool calls can be correlated with model calls.
+
+This pattern is useful when Rails MCP Server is part of a larger production AI workflow and the organization needs compliance, control, and cost reporting outside individual MCP clients.


### PR DESCRIPTION
## Summary
- add a guide for using Rails MCP Server with governed MCP clients or AI control planes
- link it from the README integration section
- use Tuning Engines as a concrete example while keeping Rails MCP Server as the MCP tool/resource server

## Why
Rails MCP Server provides Rails project tools and resources. Some production teams connect MCP servers through governed clients for role-based tool access, approvals, audit trails, and cost reporting. This documents that pattern without changing server behavior.

## Validation
- Documentation-only change