### PR TITLE
Allow sandboxed reads of system timezone data in execute_ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`execute_ruby` timezone data access**: The sandbox now allows read-only access to system timezone directories (`/usr/share/zoneinfo`, `/usr/share/lib/zoneinfo`, `/etc/zoneinfo`, `/var/db/timezone`). Previously, any code that touched `Time.zone` failed with `PATH ERROR: Access denied: path '/usr/share/zoneinfo/...' is outside project directory` because TZInfo lazily loads IANA timezone data on first use. Writes and all other out-of-project reads remain blocked.
+
 ## [1.5.1] - 2026-03-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ After switching, you'll see a Quick Start guide with common commands.
 
 **Note:** Use `puts` to see output from your code.
 
-**Security:** The sandbox prevents file writes, system calls, network access, and reading sensitive files (.env, credentials, etc.).
+**Security:** The sandbox prevents file writes, system calls, network access, and reading sensitive files (.env, credentials, etc.). File reads are limited to the project directory, plus read-only system timezone data (e.g. `/usr/share/zoneinfo`) that Rails needs when code touches `Time.zone`.
 
 ### Internal Analyzers (via execute_tool)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,7 +60,7 @@ Given that this MCP server executes code in Rails projects and provides file sys
 This project implements several security controls:
 
 - **Sandboxed execution**: `execute_ruby` tool runs code in a restricted environment with file/network/system call protections
-- **Path validation**: file operations are constrained to the configured Rails project directory
+- **Path validation**: file operations are constrained to the configured Rails project directory; the `execute_ruby` sandbox additionally allows read-only access to a small allowlist of system timezone data paths (e.g. `/usr/share/zoneinfo`)
 - **Project isolation**: each configured project has its own scope
 - **Dependency security**: automated updates via Dependabot, bundler-audit in CI
 - **Static analysis**: CodeQL scans on every PR and weekly

--- a/lib/rails-mcp-server/tools/execute_ruby.rb
+++ b/lib/rails-mcp-server/tools/execute_ruby.rb
@@ -11,7 +11,8 @@ module RailsMcpServer
       RESTRICTIONS:
       - Cannot create, modify, or delete files
       - Cannot read .env, credentials, key files, or .gitignore'd files
-      - Cannot access files outside the project directory
+      - Cannot access files outside the project directory (read-only system data
+        such as timezone files under /usr/share/zoneinfo is allowed)
       - Cannot execute shell commands or system calls
 
       HELPER METHODS AVAILABLE:
@@ -104,6 +105,18 @@ module RailsMcpServer
       /id_ed25519/i
     ].freeze
 
+    # Read-only system data directories the sandbox may read. TZInfo lazily
+    # loads IANA timezone data on first Time.zone use; these are its default
+    # search paths plus /var/db/timezone, the real location behind macOS's
+    # /usr/share/zoneinfo symlink. Writes remain blocked by the File/Dir/
+    # FileUtils overrides.
+    ALLOWED_READ_PATHS = %w[
+      /usr/share/zoneinfo
+      /usr/share/lib/zoneinfo
+      /etc/zoneinfo
+      /var/db/timezone
+    ].freeze
+
     NO_OUTPUT_MESSAGE = <<~MSG
       Code executed successfully (no output).
 
@@ -150,9 +163,13 @@ module RailsMcpServer
       sensitive_patterns_ruby = all_patterns.map { |p| "Regexp.new(#{p.inspect}, Regexp::IGNORECASE)" }.join(",\n      ")
 
       <<~RUBY
+        require "stringio" # the File.open override below yields StringIO objects
+
         # Sandbox wrapper for safe execution
         module McpSandbox
           PROJECT_ROOT = #{active_project_path.inspect}.freeze
+
+          ALLOWED_READ_PATHS = #{ALLOWED_READ_PATHS.inspect}.freeze
 
           SENSITIVE_PATTERNS = [
             #{sensitive_patterns_ruby}
@@ -166,6 +183,10 @@ module RailsMcpServer
 
           def validate_path!(path)
             expanded = File.expand_path(path, PROJECT_ROOT)
+
+            if ALLOWED_READ_PATHS.any? { |dir| expanded == dir || expanded.start_with?(dir + "/") }
+              return expanded
+            end
 
             unless expanded.start_with?(PROJECT_ROOT + "/") || expanded == PROJECT_ROOT
               raise PathViolation, "Access denied: path '\#{path}' is outside project directory"

--- a/test/tools/execute_ruby_test.rb
+++ b/test/tools/execute_ruby_test.rb
@@ -1,0 +1,100 @@
+require "test_helper"
+require "open3"
+require "tempfile"
+require "rbconfig"
+
+class ExecuteRubyTest < Minitest::Test
+  include FixtureHelpers
+
+  ZONEINFO_FILE = "/usr/share/zoneinfo/UTC"
+
+  def setup
+    setup_sample_project
+    @tool = RailsMcpServer::ExecuteRuby.new
+  end
+
+  def teardown
+    teardown_sample_project
+  end
+
+  def test_sandbox_embeds_allowed_read_paths
+    sandbox = @tool.send(:build_sandbox, "puts 1")
+
+    RailsMcpServer::ExecuteRuby::ALLOWED_READ_PATHS.each do |path|
+      assert_includes sandbox, path
+    end
+  end
+
+  def test_sandbox_allows_reading_zoneinfo
+    skip "#{ZONEINFO_FILE} not present on this system" unless File.exist?(ZONEINFO_FILE)
+
+    output = run_sandbox("puts File.read(#{ZONEINFO_FILE.inspect}).bytesize")
+
+    refute_includes output, "PATH ERROR"
+    assert_operator output.to_i, :>, 0
+  end
+
+  def test_sandbox_allows_zoneinfo_existence_checks
+    skip "#{ZONEINFO_FILE} not present on this system" unless File.exist?(ZONEINFO_FILE)
+
+    output = run_sandbox("puts File.exist?(#{ZONEINFO_FILE.inspect})")
+
+    assert_includes output, "true"
+  end
+
+  def test_sandbox_file_open_yields_readable_io_for_allowed_paths
+    skip "#{ZONEINFO_FILE} not present on this system" unless File.exist?(ZONEINFO_FILE)
+
+    output = run_sandbox("File.open(#{ZONEINFO_FILE.inspect}, \"rb\") { |f| puts f.read.bytesize }")
+
+    refute_includes output, "ERROR"
+    assert_operator output.to_i, :>, 0
+  end
+
+  def test_sandbox_blocks_system_paths_outside_allowlist
+    output = run_sandbox('puts File.read("/etc/hosts")')
+
+    assert_includes output, "PATH ERROR"
+  end
+
+  def test_sandbox_blocks_traversal_escaping_allowed_paths
+    output = run_sandbox('puts File.read("/usr/share/zoneinfo/../../../etc/hosts")')
+
+    assert_includes output, "PATH ERROR"
+  end
+
+  def test_sandbox_blocks_writes_under_allowed_paths
+    output = run_sandbox('File.write("/usr/share/zoneinfo/evil", "x")')
+
+    assert_includes output, "WRITE ERROR"
+  end
+
+  def test_sandbox_still_reads_project_files
+    output = run_sandbox("puts read_file('Gemfile')")
+
+    refute_includes output, "PATH ERROR"
+    assert_includes output, "rails"
+  end
+
+  def test_sandbox_still_blocks_sensitive_project_files
+    output = run_sandbox("puts read_file('config/master.key')")
+
+    assert_includes output, "ACCESS DENIED"
+  end
+
+  private
+
+  # Runs the generated sandbox script in a plain Ruby subprocess (without
+  # `rails runner`) and returns its stdout.
+  def run_sandbox(user_code)
+    sandbox = @tool.send(:build_sandbox, user_code)
+
+    Tempfile.create(["sandbox_test", ".rb"]) do |f|
+      f.write(sandbox)
+      f.flush
+
+      stdout, _stderr, _status = Open3.capture3(RbConfig.ruby, f.path)
+      stdout
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`execute_ruby` fails as soon as executed code touches `Time.zone`:

```
PATH ERROR: Access denied: path '/usr/share/zoneinfo/America/Los_Angeles' is outside project directory
```

The sandbox overrides `File.open`/`File.read`/`File.directory?`/etc. and rejects any path outside the project root. But TZInfo (used by ActiveSupport for `Time.zone`) lazily loads IANA timezone data from the system zoneinfo directory on first use — via `File.open(path, 'rb')` and `File.directory?`/`File.file?` checks, all of which the sandbox intercepts. Any query involving timezone conversion (a very common case with ActiveRecord timestamps) dies inside the sandbox.

Reproduced with the `ghcr.io/rails/devcontainer/images/ruby:3.4.8` devcontainer (Linux), where TZInfo uses `TZInfo::DataSources::ZoneinfoDataSource` reading `/usr/share/zoneinfo`.

## Fix

Add a default read-only allowlist of system timezone directories to the sandbox:

- `/usr/share/zoneinfo`, `/usr/share/lib/zoneinfo`, `/etc/zoneinfo` — `TZInfo::DataSources::ZoneinfoDataSource::DEFAULT_SEARCH_PATH`
- `/var/db/timezone` — the real location behind macOS's `/usr/share/zoneinfo` symlink

`McpSandbox.validate_path!` now returns early for paths inside these directories. Everything else is unchanged:

- **Writes are still blocked** everywhere, including the allowlisted directories (the `File`/`Dir`/`FileUtils` write overrides are unconditional).
- **Path traversal cannot abuse the allowlist**: `File.expand_path` normalizes `..` *before* the prefix check, so `/usr/share/zoneinfo/../../../etc/passwd` still raises `PathViolation`.
- **Prefix collisions are excluded**: the check is `expanded == dir || expanded.start_with?(dir + "/")`, so e.g. `/usr/share/zoneinfo-evil` does not match.
- All other out-of-project reads and the sensitive-file patterns behave exactly as before.

Also fixed a latent bug surfaced by end-to-end testing: the generated sandbox script now does `require "stringio"` up front. The `File.open` override yields `StringIO` objects, but nothing guaranteed StringIO was loaded — TZInfo's `File.open(path, 'rb')` is exactly the kind of call that hits this (`NameError: uninitialized constant StringIO` in environments where no earlier dependency happened to load it).

## Testing

- New `test/tools/execute_ruby_test.rb` runs the generated sandbox script in a plain Ruby subprocess and asserts:
  - reading `/usr/share/zoneinfo/UTC` succeeds; `File.exist?` returns true for it
  - `File.open('/usr/share/zoneinfo/UTC', 'rb')` yields a readable IO (the exact call TZInfo makes; also covers the `stringio` require — verified via mutation testing that this test fails if either fix is reverted)
  - `/etc/hosts` is still blocked (`PATH ERROR`)
  - traversal escaping an allowlisted dir (`/usr/share/zoneinfo/../../../etc/hosts`) is still blocked
  - writes under allowlisted dirs are still blocked (`WRITE ERROR`)
  - project files still readable; sensitive project files (`config/master.key`) still blocked
- End-to-end verification: generated a sandbox with user code `TZInfo::DataSource.set(:zoneinfo); Time.zone = "America/Los_Angeles"; puts Time.zone.now` and ran it with ActiveSupport loaded — previously raised the `PATH ERROR` above, now resolves the zone correctly through the sandboxed `File.open` (`StringIO`-backed TZif parsing works).
- Full suite: `bundle exec rake test` — 81 tests, 0 failures. `standardrb` clean on all changed files.
