### PR TITLE
Bump version to 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2] - 2026-08-03
+
 ### Fixed
 
 - **`execute_ruby` timezone data access**: The sandbox now allows read-only access to system timezone directories (`/usr/share/zoneinfo`, `/usr/share/lib/zoneinfo`, `/etc/zoneinfo`, `/var/db/timezone`). Previously, any code that touched `Time.zone` failed with `PATH ERROR: Access denied: path '/usr/share/zoneinfo/...' is outside project directory` because TZInfo lazily loads IANA timezone data on first use. Writes and all other out-of-project reads remain blocked.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails-mcp-server (1.5.1)
+    rails-mcp-server (1.5.2)
       activesupport (>= 7.0)
       addressable (~> 2.8)
       fast-mcp (~> 1.6.0)

--- a/lib/rails-mcp-server/version.rb
+++ b/lib/rails-mcp-server/version.rb
@@ -1,3 +1,3 @@
 module RailsMcpServer
-  VERSION = "1.5.1"
+  VERSION = "1.5.2"
 end


### PR DESCRIPTION
Release bump: **1.5.1 → 1.5.2**.

## Changes

- `lib/rails-mcp-server/version.rb` → `1.5.2`
- Promote the `[Unreleased]` CHANGELOG section to `[1.5.2] - 2026-08-03` (the `execute_ruby` timezone data access fix, #51) and open a fresh `[Unreleased]`
- Update the `Gemfile.lock` self-pin to `1.5.2`

## Verification

- `rake build` → `rails-mcp-server 1.5.2 built`
- `rake test` → 81 tests, 0 failures

Note: this releases what is currently on `main`. The namespaced-model resolution fix (#54) and the version-manager Ruby resolution fix (#53) are still open and will add their own changelog entries when merged; fold them into a follow-up bump if they land before cutting the release.