### PR TITLE
Bump project dependencies; drop Ruby 3.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["3.2", "3.3", "3.4"]
+        ruby-version: ["3.3", "3.4"]
 
     steps:
       - name: Checkout repository

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,1 @@
+ruby_version: 3.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Dropped Ruby 3.2 support** (breaking): The minimum supported Ruby is now 3.3 (`required_ruby_version >= 3.3.0`), and the CI matrix tests Ruby 3.3 and 3.4. Dependency updates pull in transitive gems (`dry-configurable` 1.4.0, `parallel` 2.1.0) that require Ruby >= 3.3.
+- **Dependency updates**: Bumped project dependencies, including major upgrades to `puma` (~> 8.0), `minitest` (~> 6.0) and `mocha` (~> 3.0), plus `activesupport` 8.1.3.1, `addressable` 2.9.0, `rubocop` 1.88.2, `standard` 1.56.0 and other transitive gems.
+- **Deterministic linting**: Added `.standard.yml` pinning `ruby_version: 3.3` to match the gemspec's minimum supported Ruby, so Standard/RuboCop target the supported floor regardless of the local or CI Ruby.
+
 ### Fixed
 
 - **`execute_ruby` timezone data access**: The sandbox now allows read-only access to system timezone directories (`/usr/share/zoneinfo`, `/usr/share/lib/zoneinfo`, `/etc/zoneinfo`, `/var/db/timezone`). Previously, any code that touched `Time.zone` failed with `PATH ERROR: Access denied: path '/usr/share/zoneinfo/...' is outside project directory` because TZInfo lazily loads IANA timezone data on first use. Writes and all other out-of-project reads remain blocked.
+
+### Security
+
+- **Puma advisories resolved**: Upgrading to `puma` 8.0.2 addresses CVE-2026-47736 and CVE-2026-47737 (both HIGH — PROXY Protocol v1 remote memory exhaustion and repeated-header handling). Dependency updates also clear the `concurrent-ruby` ReadWriteLock advisory (GHSA-6wx8-w4f5-wwcr). `bundler-audit` now reports no vulnerabilities.
 
 ## [1.5.1] - 2026-03-04
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,13 +6,13 @@ PATH
       addressable (~> 2.8)
       fast-mcp (~> 1.6.0)
       logger (~> 1.7)
-      puma (~> 7.1)
+      puma (~> 8.0)
       rack (~> 3.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.3)
+    activesupport (8.1.3.1)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -25,18 +25,18 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    addressable (2.8.9)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ansi (1.6.0)
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
     builder (3.3.0)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
     drb (2.2.3)
-    dry-configurable (1.3.0)
-      dry-core (~> 1.1)
+    dry-configurable (1.4.0)
+      dry-core (~> 1.0)
       zeitwerk (~> 2.6)
     dry-core (1.2.0)
       concurrent-ruby (~> 1.0)
@@ -71,39 +71,41 @@ GEM
       json (~> 2.0)
       mime-types (~> 3.4)
       rack (>= 2.0, < 4.0)
-    i18n (1.14.8)
+    i18n (1.15.2)
       concurrent-ruby (~> 1.0)
-    json (2.19.9)
-    language_server-protocol (3.17.0.5)
+    json (2.21.2)
+    language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     logger (1.7.0)
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2026.0303)
-    minitest (5.27.0)
+    mime-types-data (3.2026.0701)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
     minitest-reporters (1.8.0)
       ansi
       builder
       minitest (>= 5.0, < 7)
       ruby-progressbar
-    mocha (2.8.2)
+    mocha (3.1.0)
       ruby2_keywords (>= 0.0.5)
     nio4r (2.7.5)
-    parallel (1.28.0)
-    parser (3.3.11.1)
+    parallel (2.1.0)
+    parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
     prism (1.9.0)
     public_suffix (7.0.5)
-    puma (7.2.0)
+    puma (8.0.2)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
     rainbow (3.1.1)
     rake (13.4.2)
     regexp_parser (2.12.0)
-    rubocop (1.87.0)
+    rubocop (1.88.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -114,7 +116,7 @@ GEM
       rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.49.1)
+    rubocop-ast (1.50.0)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
     rubocop-performance (1.26.1)
@@ -124,10 +126,10 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     securerandom (0.4.1)
-    standard (1.55.0)
+    standard (1.56.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
-      rubocop (~> 1.87.0)
+      rubocop (~> 1.88.0)
       standard-custom (~> 1.0.0)
       standard-performance (~> 1.8)
     standard-custom (1.0.2)
@@ -142,16 +144,16 @@ GEM
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
     uri (1.1.1)
-    zeitwerk (2.7.5)
+    zeitwerk (2.8.3)
 
 PLATFORMS
   arm64-darwin
   ruby
 
 DEPENDENCIES
-  minitest (~> 5.25)
+  minitest (~> 6.0)
   minitest-reporters (~> 1.7)
-  mocha (~> 2.7)
+  mocha (~> 3.0)
   rails-mcp-server!
   rake
   standard

--- a/docs/COPILOT_AGENT.md
+++ b/docs/COPILOT_AGENT.md
@@ -14,7 +14,7 @@ GitHub Copilot coding agent runs MCP servers in ephemeral GitHub Actions environ
 
 - A Rails application repository on GitHub
 - GitHub Copilot with coding agent enabled
-- Ruby 3.1+ (recommended: 3.3)
+- Ruby 3.3+ (recommended: 3.4)
 
 ## Configuration
 

--- a/exe/rails-mcp-config
+++ b/exe/rails-mcp-config
@@ -219,8 +219,8 @@ module RailsMcpConfig
         print Colors.mauve(Colors.bold("#{prompt} "))
         print Colors.dim("[#{default_value}] ") unless default_value.empty?
         result = gets&.strip
-        return default_value if result&.empty? && !default_value.empty?
-        result&.empty? ? nil : result
+        return default_value if result == "" && !default_value.empty?
+        (result == "") ? nil : result
       end
     end
 

--- a/rails-mcp-server.gemspec
+++ b/rails-mcp-server.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description = "A Ruby implementation of Model Context Protocol server for Rails projects"
   spec.homepage = "https://github.com/maquina-app/rails-mcp-server"
   spec.license = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 3.2.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.3.0")
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
   spec.metadata["homepage_uri"] = spec.homepage
@@ -26,12 +26,12 @@ Gem::Specification.new do |spec|
   spec.add_dependency "addressable", "~> 2.8"
   spec.add_dependency "fast-mcp", "~> 1.6.0"
   spec.add_dependency "rack", "~> 3.2"
-  spec.add_dependency "puma", "~> 7.1"
+  spec.add_dependency "puma", "~> 8.0"
   spec.add_dependency "logger", "~> 1.7"
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "standard"
-  spec.add_development_dependency "minitest", "~> 5.25"
+  spec.add_development_dependency "minitest", "~> 6.0"
   spec.add_development_dependency "minitest-reporters", "~> 1.7"
-  spec.add_development_dependency "mocha", "~> 2.7"
+  spec.add_development_dependency "mocha", "~> 3.0"
 end


### PR DESCRIPTION
Bump project dependencies. **No version bump** — changes are recorded under the `[Unreleased]` changelog section.

## Dependencies

- **Major bumps** (gemspec caps raised): `puma ~> 7.1 → ~> 8.0`, `minitest ~> 5.25 → ~> 6.0`, `mocha ~> 2.7 → ~> 3.0`
- `bundle update` refresh: `activesupport` 8.1.3.1, `addressable` 2.9.0, `concurrent-ruby` 1.3.8, `rubocop` 1.88.2, `standard` 1.56.0, and other transitive gems

## Dropped Ruby 3.2 support (breaking)

The refreshed dependencies pull in transitive gems that require Ruby ≥ 3.3 (`dry-configurable` 1.4.0, `parallel` 2.1.0). Rather than hold them back, the minimum supported Ruby is now **3.3**:

- `required_ruby_version` → `>= 3.3.0`
- CI matrix → Ruby 3.3 and 3.4 (3.2 removed)
- `.standard.yml` target → `ruby_version: 3.3`
- `docs/COPILOT_AGENT.md` prerequisite updated

## Security

- **`bundler-audit` now clean.** Puma 8.0.2 resolves **CVE-2026-47736** and **CVE-2026-47737** (both HIGH — PROXY Protocol v1 remote memory exhaustion / repeated headers). The refresh also clears the `concurrent-ruby` ReadWriteLock advisory (GHSA-6wx8-w4f5-wwcr). These were pre-existing failures on `main`'s Security audit job.

## Tooling

- Added `.standard.yml` so Standard/RuboCop target the gemspec's minimum supported Ruby rather than the local/CI Ruby.
- Fixed a `Lint/SafeNavigationWithEmpty` offense in `exe/rails-mcp-config` surfaced by RuboCop 1.88, preserving the original nil-vs-empty-string behavior.

## Verification

- CI green: Test (Ruby 3.3, 3.4), Lint, Security audit, Lockfile validation, CodeQL — all pass
- Local: 81 tests, 0 failures · `standardrb` clean · `bundler-audit` clean
