### PR TITLE
Harden execute_ruby sandbox and document controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **`execute_ruby` sandbox hardening**: Closed several read-path bypasses and added defense-in-depth layers to the sandbox.
+  - **File-read coverage**: `IO.read`/`readlines`/`binread`/`foreach` and `File.readlines`/`binread`/`foreach` are now sandboxed too (previously only `File.read`/`open` were, so `IO.read('/etc/passwd')` and `File.readlines` bypassed path validation). The raw native readers are no longer exposed as public `File.original_read`-style aliases.
+  - **Symlink resolution**: path validation now resolves symlinks (`realpath`) before checking, so a link inside the project can't point outside it. The system-timezone allowlist is matched against canonical (symlink-resolved) locations so it keeps working on macOS.
+  - **Broader `ENV` block**: the static scan now rejects all `ENV` access (`ENV.to_h`, `ENV.values_at`, `ENV.each`, …), not just `ENV[]`/`ENV.fetch`.
+  - **Database writes rolled back**: user code runs inside a transaction that is always rolled back, so accidental `delete_all`/`update`/`save`/raw DML are undone. (Harm reduction — DDL may auto-commit on some adapters and `after_commit` callbacks are suppressed.)
+  - **Timeout actually stops runaway code**: the execution timeout now kills the entire process group, so a runaway `bin/rails runner` is terminated instead of being orphaned while the parent stops waiting.
+  - **Confirmation for dual-use constructs**: `send`, `public_send`, `const_get`, and `Kernel#open` are no longer run implicitly. The tool returns a `CONFIRMATION REQUIRED` message; callers must opt in with the new `confirm_risky: true` parameter after a human reviews the code.
 - **Puma advisories resolved**: Upgrading to `puma` 8.0.2 addresses CVE-2026-47736 and CVE-2026-47737 (both HIGH — PROXY Protocol v1 remote memory exhaustion and repeated-header handling). Dependency updates also clear the `concurrent-ruby` ReadWriteLock advisory (GHSA-6wx8-w4f5-wwcr). `bundler-audit` now reports no vulnerabilities.
 
 ## [1.5.1] - 2026-03-04

--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ After switching, you'll see a Quick Start guide with common commands.
 
 - `code`: (String, required) Ruby code to execute
 - `timeout`: (Integer, optional) Timeout in seconds (default: 30, max: 60)
+- `confirm_risky`: (Boolean, optional) Set `true` only after you have explicitly approved code that uses dual-use constructs (`send`, `public_send`, `const_get`, `Kernel#open`). When false/absent, such code is not executed — the tool returns a `CONFIRMATION REQUIRED` message explaining the risk instead.
 
 **Available helper methods:**
 
@@ -428,7 +429,16 @@ After switching, you'll see a Quick Start guide with common commands.
 
 **Note:** Use `puts` to see output from your code.
 
-**Security:** The sandbox prevents file writes, system calls, network access, and reading sensitive files (.env, credentials, etc.). File reads are limited to the project directory, plus read-only system timezone data (e.g. `/usr/share/zoneinfo`) that Rails needs when code touches `Time.zone`.
+**Security:** The sandbox is intended for read-only exploration and applies several layers of defense:
+
+- **No writes / shell / network:** file writes, `system`/`exec`/backticks, and network libraries are blocked by both static analysis and runtime overrides.
+- **Confined file reads:** reads are limited to the project directory (via all of `File`/`IO` `read`/`readlines`/`binread`/`foreach` and `File.open`), plus a small allowlist of read-only system timezone paths (e.g. `/usr/share/zoneinfo`) that Rails needs when code touches `Time.zone`. Paths are symlink-resolved (`realpath`) so a link inside the project cannot point outside it.
+- **No sensitive files:** `.env`, credentials, keys, and any `.gitignore`d path are refused.
+- **Database writes are rolled back:** user code runs inside a transaction that is always rolled back, so `delete_all`, `update`, `save`, and raw DML are undone. Treat the tool as read-only for data too. (Caveat: DDL may still commit on some adapters such as MySQL, and `after_commit` callbacks do not fire.)
+- **Bounded execution:** a timeout (default 30s, max 60s) kills the whole process group, so a runaway `bin/rails runner` is terminated rather than orphaned.
+- **Confirmation for dual-use constructs:** `send`, `public_send`, `const_get`, and `Kernel#open` are not run until you approve them via `confirm_risky: true`.
+
+These controls are defense-in-depth, not a hard isolation boundary. `execute_ruby` executes real Ruby with full access to the Rails app, so only enable it for projects and clients you trust. For stronger isolation run the server against a database user with read-only grants and/or inside an OS-level sandbox (container, `sandbox-exec`, etc.).
 
 ### Internal Analyzers (via execute_tool)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.4.x   | :white_check_mark: |
-| < 1.4   | :x:                |
+| 1.5.x   | :white_check_mark: |
+| < 1.5   | :x:                |
 
 ## Reporting a Vulnerability
 
@@ -59,12 +59,20 @@ Given that this MCP server executes code in Rails projects and provides file sys
 
 This project implements several security controls:
 
-- **Sandboxed execution**: `execute_ruby` tool runs code in a restricted environment with file/network/system call protections
-- **Path validation**: file operations are constrained to the configured Rails project directory; the `execute_ruby` sandbox additionally allows read-only access to a small allowlist of system timezone data paths (e.g. `/usr/share/zoneinfo`)
+- **Sandboxed execution**: `execute_ruby` runs code in a restricted environment with file/network/system-call protections, applied by both static analysis (a forbidden-pattern scan) and runtime overrides of `File`/`IO`/`Dir`/`FileUtils`/`Kernel`
+- **Path validation**: file operations are constrained to the configured Rails project directory. The `execute_ruby` sandbox resolves symlinks (`realpath`) before validating, so a link inside the project cannot point outside it, and covers every `File`/`IO` read entry point (`read`, `readlines`, `binread`, `foreach`, `open`). It additionally allows read-only access to a small allowlist of system timezone paths (e.g. `/usr/share/zoneinfo`), matched against their canonical (symlink-resolved) locations
+- **Sensitive-file protection**: `.env`, credentials, keys, and any `.gitignore`d path are refused; environment-variable access (`ENV`) is blocked by the static scan
+- **Read-only database access**: `execute_ruby` runs user code inside a transaction that is always rolled back, so accidental writes (`delete_all`, `update`, `save`, raw DML) are undone. This is harm reduction, not a guarantee — DDL may auto-commit on some adapters (e.g. MySQL) and `after_commit` callbacks are suppressed
+- **Resource bounds**: `execute_ruby` enforces a timeout (default 30s, max 60s) by killing the entire process group, preventing an orphaned runaway `bin/rails runner`
+- **Confirmation for dual-use constructs**: `send`, `public_send`, `const_get`, and `Kernel#open` are not executed until the caller opts in via `confirm_risky: true`, so a human can review them first
 - **Project isolation**: each configured project has its own scope
 - **Dependency security**: automated updates via Dependabot, bundler-audit in CI
 - **Static analysis**: CodeQL scans on every PR and weekly
 - **Code review**: all changes require review before merging
+
+### Known limitations
+
+The `execute_ruby` controls are defense-in-depth, not a hard isolation boundary. The tool executes real Ruby with full access to the Rails application, so metaprogramming can, in principle, still reach otherwise-blocked APIs, DDL and non-default-connection writes can escape the transaction rollback, and there are no per-process CPU/memory caps beyond the timeout. Only enable `execute_ruby` for projects and clients you trust. For stronger guarantees, run the server against a database user with read-only grants and/or inside an OS-level sandbox (container, `sandbox-exec`, seccomp, etc.).
 
 ## Acknowledgments
 

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -225,6 +225,10 @@ railsMcpServer:execute_ruby code: "read_file('Gemfile')"
 railsMcpServer:execute_ruby code: "puts read_file('Gemfile')"
 ```
 
+**Read-only by design:** `execute_ruby` is for exploration, not mutation. File writes, shell/system calls, and network access are blocked, and any database writes run inside a transaction that is **always rolled back** — so `delete_all`, `update`, and `save` will not persist. Do not rely on it to change data.
+
+**Confirmation for dual-use constructs:** if your code uses `send`, `public_send`, `const_get`, or `Kernel#open`, the tool returns a `CONFIRMATION REQUIRED` message instead of running. These can bypass the sandbox's safety scan, so ask the user to review the code and, only with their explicit approval, re-invoke with `confirm_risky: true`. Do not set `confirm_risky` on your own.
+
 ---
 
 ## Tool Selection Summary

--- a/lib/rails-mcp-server/tools/execute_ruby.rb
+++ b/lib/rails-mcp-server/tools/execute_ruby.rb
@@ -14,6 +14,9 @@ module RailsMcpServer
       - Cannot access files outside the project directory (read-only system data
         such as timezone files under /usr/share/zoneinfo is allowed)
       - Cannot execute shell commands or system calls
+      - Database writes run inside a transaction that is always rolled back, so
+        treat this as read-only for data too (note: DDL may still commit on some
+        adapters, and after_commit callbacks do not fire)
 
       HELPER METHODS AVAILABLE:
       - read_file(path) - safely read a file
@@ -22,11 +25,17 @@ module RailsMcpServer
       - project_root - returns the project root path
 
       NOTE: Use `puts` to see output, e.g., puts read_file('Gemfile')
+
+      Some dual-use constructs (Kernel#open, send, public_send, const_get) are
+      not run immediately: the tool returns a CONFIRMATION REQUIRED message
+      explaining the risk. Re-invoke with confirm_risky: true only after the
+      user has reviewed the code and approved it.
     DESC
 
     arguments do
       required(:code).filled(:string).description("Ruby code to execute (read-only operations only)")
       optional(:timeout).filled(:integer).description("Timeout in seconds. Default: 30, Max: 60")
+      optional(:confirm_risky).filled(:bool).description("Set true ONLY after the user has explicitly approved running code that uses sandbox-bypass-capable constructs (send, public_send, const_get, Kernel#open). When false/absent, such code is not executed; the tool returns a CONFIRMATION REQUIRED message instead.")
     end
 
     # Patterns that indicate dangerous operations
@@ -76,14 +85,30 @@ module RailsMcpServer
       /set_trace_func/i,
 
       # Environment/credentials access
-      /ENV\[/i,
-      /ENV\.fetch/i,
+      # Match any ENV usage (ENV[, ENV.fetch, ENV.to_h, ENV.values_at, ENV.each,
+      # ...). Case-sensitive so it doesn't flag `Rails.env` or a local `env`.
+      /\bENV\b/,
       /Rails\.application\.credentials/i,
       /Rails\.application\.secrets/i,
 
       # Load/require that could execute arbitrary code
       /load\s*[(\s]+[^)]*\$/i,
       /require\s+[^'"]/i
+    ].freeze
+
+    # Dual-use constructs that are NOT hard-blocked (they have legitimate
+    # read-only uses) but can defeat the static safety scan, so running them
+    # requires explicit user confirmation via confirm_risky: true.
+    # Each entry: [pattern, label, why-it-is-risky].
+    CONFIRMATION_REQUIRED_PATTERNS = [
+      [/(?<![.\w])open\s*\(/, "Kernel#open",
+        "`open(arg)` runs a shell command when arg begins with '|', and can open network/URI targets — both escape the sandbox."],
+      [/\bpublic_send\b/, "public_send",
+        "dynamic dispatch can invoke methods the static scan cannot see, e.g. reaching blocked system/file APIs indirectly."],
+      [/\bsend\s*[(\s]/, "send",
+        "dynamic dispatch can invoke methods the static scan cannot see, e.g. reaching blocked system/file APIs indirectly."],
+      [/\bconst_get\b/, "const_get",
+        "resolves constants by name at runtime, which can reach classes the static scan would otherwise block."]
     ].freeze
 
     # Sensitive file patterns (in addition to .gitignore)
@@ -126,7 +151,7 @@ module RailsMcpServer
         puts Dir.glob('app/models/*.rb')
     MSG
 
-    def call(code:, timeout: 30)
+    def call(code:, timeout: 30, confirm_risky: false)
       unless current_project
         return "No active project. Please switch to a project first."
       end
@@ -134,14 +159,20 @@ module RailsMcpServer
       timeout = [timeout.to_i, 60].min # Cap at 60 seconds
       timeout = 10 if timeout < 1
 
-      # Step 1: Static analysis - reject dangerous code
+      # Step 1: Static analysis - reject outright-dangerous code
       validation_error = validate_code_safety(code)
       return validation_error if validation_error
 
-      # Step 2: Build the sandboxed execution environment
+      # Step 2: Dual-use constructs require explicit user confirmation
+      unless confirm_risky
+        confirmation = confirmation_required(code)
+        return confirmation if confirmation
+      end
+
+      # Step 3: Build the sandboxed execution environment
       sandbox_code = build_sandbox(code)
 
-      # Step 3: Execute with timeout
+      # Step 4: Execute with timeout
       execute_sandboxed(sandbox_code, timeout)
     end
 
@@ -157,6 +188,23 @@ module RailsMcpServer
       nil
     end
 
+    # Returns a message asking the model to confirm with the user when the code
+    # uses dual-use constructs, or nil when there is nothing to confirm.
+    def confirmation_required(code)
+      matched = CONFIRMATION_REQUIRED_PATTERNS.select { |pattern, _label, _reason| code.match?(pattern) }
+      return nil if matched.empty?
+
+      details = matched.map { |_pattern, label, reason| "  - `#{label}`: #{reason}" }.join("\n")
+
+      <<~MSG
+        CONFIRMATION REQUIRED: This code uses constructs that can bypass the sandbox's static safety checks:
+
+        #{details}
+
+        These are not blocked outright because they have legitimate read-only uses, but they can reach APIs the safety scan would otherwise stop. Ask the user to review the code and confirm they want to run it. If they approve, re-invoke execute_ruby with confirm_risky: true. Do not set confirm_risky yourself without the user's explicit approval.
+      MSG
+    end
+
     def build_sandbox(user_code)
       gitignore_patterns = parse_gitignore
       all_patterns = SENSITIVE_PATTERNS.map(&:source) + gitignore_patterns
@@ -167,13 +215,40 @@ module RailsMcpServer
 
         # Sandbox wrapper for safe execution
         module McpSandbox
-          PROJECT_ROOT = #{active_project_path.inspect}.freeze
+          # realpath-normalized so symlink resolution below compares against the
+          # canonical root (e.g. macOS /var -> /private/var) rather than a path
+          # that would never prefix-match a resolved target.
+          PROJECT_ROOT = File.realpath(#{active_project_path.inspect}).freeze
 
           ALLOWED_READ_PATHS = #{ALLOWED_READ_PATHS.inspect}.freeze
+
+          # realpath-resolved forms of the allowlist, so a resolved target still
+          # matches when the allowed dir is itself a symlink (e.g. macOS
+          # /usr/share/zoneinfo -> /private/var/db/timezone/.../zoneinfo).
+          CANONICAL_ALLOWED_READ_PATHS = ALLOWED_READ_PATHS.map { |dir|
+            File.exist?(dir) ? File.realpath(dir) : dir
+          }.freeze
 
           SENSITIVE_PATTERNS = [
             #{sensitive_patterns_ruby}
           ].freeze
+
+          # Native method handles captured *before* the File/Dir overrides below
+          # replace them. Held in private constants so sandboxed user code has no
+          # public `File.original_read`-style alias to call the raw method back.
+          ORIGINAL_FILE_READ      = File.method(:read)
+          ORIGINAL_FILE_READLINES = File.method(:readlines)
+          ORIGINAL_FILE_BINREAD   = File.method(:binread)
+          ORIGINAL_FILE_EXIST     = File.method(:exist?)
+          ORIGINAL_FILE_DIRECTORY = File.method(:directory?)
+          ORIGINAL_FILE_FILE      = File.method(:file?)
+          ORIGINAL_FILE_REALPATH  = File.method(:realpath)
+          ORIGINAL_DIR_GLOB       = Dir.method(:glob)
+          ORIGINAL_DIR_ENTRIES    = Dir.method(:entries)
+          private_constant :ORIGINAL_FILE_READ, :ORIGINAL_FILE_READLINES,
+            :ORIGINAL_FILE_BINREAD, :ORIGINAL_FILE_EXIST, :ORIGINAL_FILE_DIRECTORY,
+            :ORIGINAL_FILE_FILE, :ORIGINAL_FILE_REALPATH, :ORIGINAL_DIR_GLOB,
+            :ORIGINAL_DIR_ENTRIES
 
           class PathViolation < StandardError; end
           class SensitiveFileViolation < StandardError; end
@@ -181,18 +256,32 @@ module RailsMcpServer
 
           module_function
 
+          # Resolve symlinks so a link *inside* the project cannot be used to
+          # read a target outside it. realpath needs the path to exist, so for a
+          # not-yet-existing path resolve the deepest existing ancestor and
+          # re-append the remainder (which still catches a symlinked ancestor).
+          def resolve_symlinks(expanded)
+            return ORIGINAL_FILE_REALPATH.call(expanded) if ORIGINAL_FILE_EXIST.call(expanded)
+
+            parent = File.dirname(expanded)
+            return expanded if parent == expanded
+
+            File.join(resolve_symlinks(parent), File.basename(expanded))
+          end
+
           def validate_path!(path)
             expanded = File.expand_path(path, PROJECT_ROOT)
+            resolved = resolve_symlinks(expanded)
 
-            if ALLOWED_READ_PATHS.any? { |dir| expanded == dir || expanded.start_with?(dir + "/") }
-              return expanded
+            if (ALLOWED_READ_PATHS + CANONICAL_ALLOWED_READ_PATHS).any? { |dir| resolved == dir || resolved.start_with?(dir + "/") }
+              return resolved
             end
 
-            unless expanded.start_with?(PROJECT_ROOT + "/") || expanded == PROJECT_ROOT
+            unless resolved.start_with?(PROJECT_ROOT + "/") || resolved == PROJECT_ROOT
               raise PathViolation, "Access denied: path '\#{path}' is outside project directory"
             end
 
-            relative_path = expanded.sub(PROJECT_ROOT + "/", "")
+            relative_path = resolved.sub(PROJECT_ROOT + "/", "")
 
             SENSITIVE_PATTERNS.each do |pattern|
               if relative_path.match?(pattern)
@@ -200,37 +289,48 @@ module RailsMcpServer
               end
             end
 
-            expanded
+            resolved
           end
 
           def safe_read(path)
-            validated_path = validate_path!(path)
-            File.original_read(validated_path)
+            ORIGINAL_FILE_READ.call(validate_path!(path))
+          end
+
+          def safe_readlines(path)
+            ORIGINAL_FILE_READLINES.call(validate_path!(path))
+          end
+
+          def safe_binread(path)
+            ORIGINAL_FILE_BINREAD.call(validate_path!(path))
+          end
+
+          def safe_foreach(path, &block)
+            lines = safe_readlines(path)
+            return lines.each unless block
+
+            lines.each(&block)
           end
 
           def safe_exist?(path)
-            validated_path = validate_path!(path)
-            File.original_exist?(validated_path)
+            ORIGINAL_FILE_EXIST.call(validate_path!(path))
           rescue PathViolation, SensitiveFileViolation
             false
           end
 
           def safe_directory?(path)
-            validated_path = validate_path!(path)
-            File.original_directory?(validated_path)
+            ORIGINAL_FILE_DIRECTORY.call(validate_path!(path))
           rescue PathViolation, SensitiveFileViolation
             false
           end
 
           def safe_file?(path)
-            validated_path = validate_path!(path)
-            File.original_file?(validated_path)
+            ORIGINAL_FILE_FILE.call(validate_path!(path))
           rescue PathViolation, SensitiveFileViolation
             false
           end
 
           def safe_glob(pattern, base: PROJECT_ROOT)
-            Dir.original_glob(File.join(base, pattern)).select do |path|
+            ORIGINAL_DIR_GLOB.call(File.join(base, pattern)).select do |path|
               validate_path!(path)
               true
             rescue PathViolation, SensitiveFileViolation
@@ -239,21 +339,56 @@ module RailsMcpServer
           end
 
           def safe_entries(path)
-            validated_path = validate_path!(path)
-            Dir.original_entries(validated_path).reject { |e| e.start_with?(".") }
+            ORIGINAL_DIR_ENTRIES.call(validate_path!(path)).reject { |e| e.start_with?(".") }
+          end
+
+          # True only when ActiveRecord is loaded *and* a connection can be
+          # obtained, so we never turn a pure-Ruby read-only snippet into a
+          # database connection error just to wrap it in a transaction.
+          def database_available?
+            return false unless defined?(ActiveRecord::Base)
+
+            ActiveRecord::Base.connection
+            true
+          rescue StandardError
+            false
+          end
+
+          # Run the block inside a transaction that is *always* rolled back, so
+          # accidental writes are undone. Harm reduction, not a guarantee: DDL
+          # auto-commits on some adapters (e.g. MySQL) and after_commit
+          # callbacks are suppressed. Falls back to a plain call when no
+          # database is available. Real exceptions still propagate (and also
+          # trigger the rollback).
+          def readonly_guard
+            return yield unless database_available?
+
+            result = nil
+            ActiveRecord::Base.transaction do
+              result = yield
+              raise ActiveRecord::Rollback
+            end
+            result
           end
         end
 
         # Override File class methods
         class File
           class << self
-            alias_method :original_read, :read
-            alias_method :original_exist?, :exist?
-            alias_method :original_directory?, :directory?
-            alias_method :original_file?, :file?
-
             def read(path, *args)
               McpSandbox.safe_read(path)
+            end
+
+            def readlines(path, *args)
+              McpSandbox.safe_readlines(path)
+            end
+
+            def binread(path, *args)
+              McpSandbox.safe_binread(path)
+            end
+
+            def foreach(path, *args, &block)
+              McpSandbox.safe_foreach(path, &block)
             end
 
             def exist?(path)
@@ -293,9 +428,6 @@ module RailsMcpServer
         # Override Dir class methods
         class Dir
           class << self
-            alias_method :original_glob, :glob
-            alias_method :original_entries, :entries
-
             def glob(pattern, *args)
               McpSandbox.safe_glob(pattern)
             end
@@ -308,6 +440,29 @@ module RailsMcpServer
               define_method(method) do |*args|
                 raise McpSandbox::WriteViolation, "Directory modifications are not permitted: Dir.\#{method}"
               end
+            end
+          end
+        end
+
+        # Override IO read entry points. File < IO, but IO.read / IO.readlines /
+        # IO.binread / IO.foreach are separate class methods that bypass the File
+        # overrides above, so they must be sandboxed independently.
+        class IO
+          class << self
+            def read(path, *args)
+              McpSandbox.safe_read(path)
+            end
+
+            def readlines(path, *args)
+              McpSandbox.safe_readlines(path)
+            end
+
+            def binread(path, *args)
+              McpSandbox.safe_binread(path)
+            end
+
+            def foreach(path, *args, &block)
+              McpSandbox.safe_foreach(path, &block)
             end
           end
         end
@@ -367,8 +522,13 @@ module RailsMcpServer
         end
 
         # ============ USER CODE BELOW ============
+        # Wrapped in an always-rolled-back transaction so accidental DB writes
+        # (delete_all, update, save, raw DML) are undone. See McpSandbox
+        # .readonly_guard for the caveats; it's a no-op without a database.
         begin
-          #{user_code}
+          McpSandbox.readonly_guard do
+            #{user_code}
+          end
         rescue McpSandbox::PathViolation => e
           puts "PATH ERROR: \#{e.message}"
         rescue McpSandbox::SensitiveFileViolation => e
@@ -407,23 +567,19 @@ module RailsMcpServer
 
     def execute_sandboxed(code, timeout)
       require "tempfile"
-      require "timeout"
 
       Tempfile.create(["mcp_sandbox", ".rb"]) do |f|
         f.write(code)
         f.flush
 
-        begin
-          Timeout.timeout(timeout) do
-            result = RailsMcpServer::RunProcess.execute_rails_command(
-              active_project_path,
-              "bin/rails runner #{f.path} 2>&1"
-            )
-            result.empty? ? NO_OUTPUT_MESSAGE : result
-          end
-        rescue Timeout::Error
-          "TIMEOUT: Execution exceeded #{timeout} seconds"
-        end
+        # RunProcess enforces the timeout by killing the whole process group, so
+        # a runaway `rails runner` is actually terminated rather than orphaned.
+        result = RailsMcpServer::RunProcess.execute_rails_command(
+          active_project_path,
+          "bin/rails runner #{f.path} 2>&1",
+          timeout: timeout
+        )
+        result.to_s.empty? ? NO_OUTPUT_MESSAGE : result
       end
     end
   end

--- a/lib/rails-mcp-server/utilities/run_process.rb
+++ b/lib/rails-mcp-server/utilities/run_process.rb
@@ -1,9 +1,14 @@
 require "bundler"
 require "shellwords"
+require "open3"
+require "timeout"
 
 module RailsMcpServer
   class RunProcess
-    def self.execute_rails_command(project_path, command)
+    # `timeout` (seconds) bounds execution. When set, the command runs in its
+    # own process group so a timeout kills the whole tree; nil keeps the
+    # original unbounded behavior.
+    def self.execute_rails_command(project_path, command, timeout: nil)
       RailsMcpServer.log(:debug, "Executing: #{command}")
 
       Bundler.with_unbundled_env do
@@ -26,7 +31,12 @@ module RailsMcpServer
         # ahead of the manager's shims — the exact reason the system Ruby leaked
         # in. It also never sources ~/.zshrc, where mise/asdf activation usually
         # lives. `-c` keeps the PATH we assembled above intact.
-        stdout_str, stderr_str, status = Open3.capture3(subprocess_env, shell, "-c", shell_command)
+        stdout_str, stderr_str, status =
+          if timeout
+            capture3_with_timeout(subprocess_env, shell, shell_command, timeout)
+          else
+            Open3.capture3(subprocess_env, shell, "-c", shell_command)
+          end
 
         if status.success?
           RailsMcpServer.log(:debug, "Command succeeded")
@@ -39,9 +49,46 @@ module RailsMcpServer
           "Error executing Rails command: #{command}\n\n#{error_output}"
         end
       end
+    rescue Timeout::Error
+      RailsMcpServer.log(:error, "Command timed out after #{timeout} seconds")
+      "TIMEOUT: Execution exceeded #{timeout} seconds"
     rescue => e
       RailsMcpServer.log(:error, "Exception executing Rails command: #{e.message}")
       "Exception executing command: #{e.message}"
+    end
+
+    # Run the command in its own process group so a timeout can kill the entire
+    # tree (the shell *and* its `rails runner` grandchild). Open3.capture3 gives
+    # no handle to signal the group, so drive popen3 directly and drain stdout/
+    # stderr on separate threads to avoid a full-pipe deadlock. Re-raises
+    # Timeout::Error after killing; the caller maps it to a user-facing message.
+    def self.capture3_with_timeout(env, shell, shell_command, timeout)
+      Open3.popen3(env, shell, "-c", shell_command, pgroup: true) do |stdin, stdout, stderr, wait_thr|
+        stdin.close
+        out = +""
+        err = +""
+        out_reader = Thread.new { out << stdout.read }
+        err_reader = Thread.new { err << stderr.read }
+
+        begin
+          status = Timeout.timeout(timeout) { wait_thr.value }
+          out_reader.join
+          err_reader.join
+          [out, err, status]
+        rescue Timeout::Error
+          kill_process_group(wait_thr.pid)
+          out_reader.join(1)
+          err_reader.join(1)
+          raise
+        end
+      end
+    end
+
+    # KILL the process group led by `pid`. Negative pid targets the whole group.
+    def self.kill_process_group(pid)
+      Process.kill("KILL", -Process.getpgid(pid))
+    rescue Errno::ESRCH, Errno::EPERM
+      # Already exited or not signalable; nothing to clean up.
     end
 
     # Shim directories for the version managers installed on this machine,

--- a/test/tools/execute_ruby_test.rb
+++ b/test/tools/execute_ruby_test.rb
@@ -82,6 +82,139 @@ class ExecuteRubyTest < Minitest::Test
     assert_includes output, "ACCESS DENIED"
   end
 
+  # Fix 1: IO.read is a separate entry point from File.read and must be sandboxed.
+  def test_sandbox_blocks_io_read_outside_project
+    output = run_sandbox('puts IO.read("/etc/hosts")')
+
+    assert_includes output, "PATH ERROR"
+  end
+
+  # Fix 1: File.readlines is a sibling of File.read and must be sandboxed.
+  def test_sandbox_blocks_file_readlines_outside_project
+    output = run_sandbox('puts File.readlines("/etc/hosts").length')
+
+    assert_includes output, "PATH ERROR"
+  end
+
+  # Fix 1: sensitive project files are blocked via IO.read too, not just File.read.
+  def test_sandbox_blocks_sensitive_files_via_io_read
+    output = run_sandbox("puts IO.read('config/master.key')")
+
+    assert_includes output, "ACCESS DENIED"
+  end
+
+  # Fix 2: the raw native reader is no longer exposed as a public alias.
+  def test_sandbox_does_not_expose_original_read_alias
+    output = run_sandbox('puts File.original_read("/etc/hosts")')
+
+    assert_includes output, "ERROR"
+    refute_includes output, "127.0.0.1"
+  end
+
+  # Fix 3: a symlink inside the project must not read a target outside it.
+  def test_sandbox_blocks_symlink_escaping_project
+    link = File.join(sample_project_path, "escape_hatch_test_link")
+    File.symlink("/etc/hosts", link)
+
+    output = run_sandbox('puts File.read("escape_hatch_test_link")')
+
+    assert_includes output, "PATH ERROR"
+  ensure
+    File.unlink(link) if link && File.symlink?(link)
+  end
+
+  # Fix 4: ENV access beyond ENV[] / ENV.fetch is rejected by static analysis.
+  def test_static_analysis_rejects_broad_env_access
+    %w[ENV.to_h ENV.values_at("X") ENV.each ENV["X"]].each do |snippet|
+      error = @tool.send(:validate_code_safety, "puts #{snippet}")
+
+      refute_nil error, "expected #{snippet} to be rejected"
+      assert_includes error, "REJECTED"
+    end
+  end
+
+  # Fix 4: `Rails.env` must not trip the ENV pattern (case-sensitive \bENV\b).
+  def test_static_analysis_allows_rails_env
+    assert_nil @tool.send(:validate_code_safety, "puts Rails.env")
+  end
+
+  # DB harm-reduction: without ActiveRecord the guard is a transparent no-op,
+  # so ordinary read-only code still runs and returns output.
+  def test_readonly_guard_is_noop_without_active_record
+    output = run_sandbox("puts 21 * 2")
+
+    assert_includes output, "42"
+    refute_includes output, "ERROR"
+  end
+
+  # DB harm-reduction: when a database is available the user code runs inside a
+  # transaction that is forced to roll back. Exercised with a stub ActiveRecord.
+  def test_readonly_guard_forces_rollback_when_database_available
+    output = run_sandbox(<<~RUBY)
+      module ActiveRecord
+        class Rollback < StandardError; end
+        class Base
+          @rolled_back = false
+          def self.connection = :stub
+          def self.rolled_back? = @rolled_back
+          def self.transaction
+            yield
+          rescue ActiveRecord::Rollback
+            @rolled_back = true
+          end
+        end
+      end
+
+      ran = false
+      McpSandbox.readonly_guard { ran = true }
+      puts "ran=\#{ran} rolled_back=\#{ActiveRecord::Base.rolled_back?}"
+    RUBY
+
+    assert_includes output, "ran=true rolled_back=true"
+  end
+
+  # Confirmation tier: dual-use constructs are not executed without confirm_risky.
+  def test_dual_use_constructs_require_confirmation
+    {
+      "obj.send(:foo)" => "send",
+      "obj.public_send(:foo)" => "public_send",
+      "Object.const_get(:Kernel)" => "const_get",
+      'open("somefile")' => "Kernel#open"
+    }.each do |snippet, label|
+      result = @tool.send(:confirmation_required, "puts #{snippet}")
+
+      refute_nil result, "expected #{snippet} to require confirmation"
+      assert_includes result, "CONFIRMATION REQUIRED"
+      assert_includes result, label
+      assert_includes result, "confirm_risky: true"
+    end
+  end
+
+  # Confirmation tier: File.open and similar receiver.open calls are not flagged
+  # as Kernel#open, and ordinary code needs no confirmation.
+  def test_confirmation_not_required_for_safe_code
+    assert_nil @tool.send(:confirmation_required, "puts File.open('Gemfile').read")
+    assert_nil @tool.send(:confirmation_required, "puts read_file('Gemfile')")
+    assert_nil @tool.send(:confirmation_required, "puts User.count")
+  end
+
+  # Confirmation tier: call() returns the confirmation message instead of running
+  # the code when confirm_risky is not set.
+  def test_call_returns_confirmation_message_without_confirm_risky
+    result = @tool.call(code: "puts [].send(:length)")
+
+    assert_includes result, "CONFIRMATION REQUIRED"
+  end
+
+  # Confirmation tier: with confirm_risky: true the code runs (proven by output).
+  def test_call_executes_risky_code_with_confirm_risky
+    @tool.stubs(:execute_sandboxed).returns("executed")
+
+    result = @tool.call(code: "puts [].send(:length)", confirm_risky: true)
+
+    assert_equal "executed", result
+  end
+
   private
 
   # Runs the generated sandbox script in a plain Ruby subprocess (without


### PR DESCRIPTION
## Summary

Hardens the `execute_ruby` sandbox by closing several read-path bypasses and adding defense-in-depth layers, then updates the docs to match. These controls are defense-in-depth, not a hard isolation boundary — the tool still executes real Ruby with full app access — but they close the *no-tricks-needed* holes and make the "read-only" contract meaningfully true for files **and** data.

## Sandbox changes (`lib/rails-mcp-server/tools/execute_ruby.rb`)

- **File-read coverage:** sandbox all `File`/`IO` read entry points (`read`, `readlines`, `binread`, `foreach`, `open`). Previously only `File.read`/`open` were guarded, so `IO.read('/etc/passwd')` and `File.readlines` bypassed path validation entirely.
- **No native-reader alias leak:** capture native readers in private constants instead of leaving public `File.original_read`-style aliases callable from user code.
- **Symlink resolution:** resolve symlinks (`realpath`) before path validation so a link inside the project can't point outside it. The system-timezone allowlist is matched against canonical (resolved) locations so it still works on macOS.
- **Broader `ENV` block:** the static scan now rejects all `ENV` access (`ENV.to_h`, `ENV.values_at`, `ENV.each`, …), not just `ENV[]`/`ENV.fetch`. Case-sensitive so `Rails.env` is unaffected.
- **DB writes rolled back:** user code runs inside a transaction that is always rolled back, so accidental `delete_all`/`update`/`save`/raw DML are undone. Harm reduction — DDL may auto-commit on some adapters (MySQL) and `after_commit` callbacks are suppressed. No-op when no database is available.
- **Confirmation tier:** `send`, `public_send`, `const_get`, and `Kernel#open` return a `CONFIRMATION REQUIRED` message and only execute with the new `confirm_risky: true` parameter, keeping a human in the loop for dual-use constructs.

## Timeout change (`lib/rails-mcp-server/utilities/run_process.rb`)

- Add an optional `timeout:` that runs the command in its own **process group** and kills the group on expiry. The previous `Timeout.timeout` wrapper around `Open3.capture3` unwound the parent but orphaned the `rails runner` child; verified it now dies in ~1s with no leftover process.

## Docs

- **README:** documented `confirm_risky`; rewrote the `execute_ruby` Security section into a layered list with an honest "not a hard boundary" caveat.
- **SECURITY:** fixed the stale supported-versions table (1.4.x → 1.5.x), expanded Security Measures, added a **Known limitations** section.
- **CHANGELOG:** entry under `[Unreleased] → Security`.
- **docs/AGENT:** "read-only by design" + "don't self-approve `confirm_risky`" notes.

## Testing

- 14 new tests covering: `IO.read`/`File.readlines` blocked outside project, sensitive files blocked via `IO.read`, `original_read` alias gone, symlink-escape blocked, broad `ENV` rejected / `Rails.env` allowed, rollback guard (no-op without AR + forced rollback with a stub AR), and the confirmation tier.
- Full suite green: **110 tests, 377 assertions, 0 failures**. `standardrb` clean.
- Process-group timeout kill and `TIMEOUT:` mapping verified live.

## Known limitations (also documented)

Metaprogramming can in principle still reach otherwise-blocked APIs; DDL and non-default-connection writes can escape the rollback; no CPU/memory caps beyond the timeout. For stronger guarantees, run against a read-only DB role and/or inside an OS-level sandbox (container, `sandbox-exec`, seccomp).