### PR TITLE
Credit Pluto Security in SECURITY.md acknowledgments

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -79,4 +79,4 @@ The tools are read-oriented, but this is not enforced by an isolation boundary: 
 
 We thank the following researchers for responsibly disclosing vulnerabilities:
 
-*No vulnerabilities reported yet.*
+- **Pluto Security** — reported a command-execution vulnerability in the `execute_ruby` tool: arbitrary host commands via `PTY.spawn`, escaping the sandbox's pattern denylist. Addressed by hardening in 1.6.1 and by removing the `execute_ruby` tool entirely in 2.0.0.


### PR DESCRIPTION
Adds the researcher (Pluto Security) to the SECURITY.md Acknowledgments section, which still read "No vulnerabilities reported yet."

Credits the responsible disclosure of the `execute_ruby` command-execution vulnerability (arbitrary host commands via `PTY.spawn`, escaping the pattern denylist), noting it was addressed by hardening in 1.6.1 and by removing the tool in 2.0.0.

Merging before tagging v2.0.0 so the credit ships in the release.

https://claude.ai/code/session_018a3pM2YUuLgvWjR8HkYznw